### PR TITLE
Update vpc-setup.yml

### DIFF
--- a/modules/vpc-setup.yml
+++ b/modules/vpc-setup.yml
@@ -1,7 +1,13 @@
+- name: remove key pair by name
+  amazon.aws.ec2_key:
+    name: "{{ vpc_tag }}"
+    region: "{{ aws_region }}"
+    state: absent
+    
 - name: Create a new EC2 key
   ec2_key:
-      name: "{{ vpc_tag }}"
-      region: "{{ aws_region }}"
+    name: "{{ vpc_tag }}"
+    region: "{{ aws_region }}"
   register: ec2_key_result
 
 - name: "Save private key as {{ ansible_ssh_private_key_file }}"


### PR DESCRIPTION
Remove the key.pem file in case prev ec2 instances were removed manually from console w/o removing key. 
If the key already exists  in aws - 

THE following will not return true

- name: Create a new EC2 key
  ec2_key:
    name: "{{ vpc_tag }}"
    region: "{{ aws_region }}"
  register: ec2_key_result

therefore copy command never saves the key per file